### PR TITLE
Add XcodePlugin support from BookBeat:xcodeproject-support

### DIFF
--- a/Plugins/SwiftGenPlugin/Plugin.swift
+++ b/Plugins/SwiftGenPlugin/Plugin.swift
@@ -31,6 +31,33 @@ struct SwiftGenPlugin: BuildToolPlugin {
   }
 }
 
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension SwiftGenPlugin: XcodeBuildToolPlugin {
+  func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
+    let fileManager = FileManager.default
+
+    // Possible paths where there may be a config file (root of package, target dir.)
+    let configurations: [Path] = [context.xcodeProject.directory]
+      .map { $0.appending("swiftgen.yml") }
+      .filter { fileManager.fileExists(atPath: $0.string) }
+
+    // Validate paths list
+    guard validate(configurations: configurations, target: target) else {
+      return []
+    }
+
+    // Clear the SwiftGen plugin's directory (in case of dangling files)
+    fileManager.forceClean(directory: context.pluginWorkDirectory)
+
+    return try configurations.map { configuration in
+      try .swiftgen(using: configuration, context: context, target: target)
+    }
+  }
+}
+#endif
+
 // MARK: - Helpers
 
 private extension SwiftGenPlugin {
@@ -47,6 +74,21 @@ private extension SwiftGenPlugin {
 
     return true
   }
+
+#if canImport(XcodeProjectPlugin)
+  func validate(configurations: [Path], target: XcodeTarget) -> Bool {
+    guard !configurations.isEmpty else {
+      Diagnostics.error("""
+        No SwiftGen configurations found for target \(target.displayName). If you would like to generate sources for this \
+        target include a `swiftgen.yml` in the target's source directory, or include a shared `swiftgen.yml` at the \
+        package's root.
+        """)
+      return false
+    }
+
+    return true
+  }
+#endif
 }
 
 private extension Command {
@@ -69,6 +111,27 @@ private extension Command {
       outputFilesDirectory: context.pluginWorkDirectory
     )
   }
+
+#if canImport(XcodeProjectPlugin)
+  static func swiftgen(using configuration: Path, context: XcodePluginContext, target: XcodeTarget) throws -> Command {
+    .prebuildCommand(
+      displayName: "SwiftGen BuildTool Plugin",
+      executable: try context.tool(named: "swiftgen").path,
+      arguments: [
+        "config",
+        "run",
+        "--verbose",
+        "--config", "\(configuration)"
+      ],
+      environment: [
+        "PROJECT_DIR": context.xcodeProject.directory,
+        "TARGET_NAME": target.displayName,
+        "DERIVED_SOURCES_DIR": context.pluginWorkDirectory
+      ],
+      outputFilesDirectory: context.pluginWorkDirectory
+    )
+  }
+#endif
 }
 
 private extension FileManager {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added support for `XcodeBuildToolPlugin` to `SwiftGenPlugin`, enabling integration with Xcode projects.
- Implemented the `createBuildCommands` method to generate build commands in the context of an Xcode project.
- Introduced conditional compilation to import `XcodeProjectPlugin` and extend functionality when available.
- Enhanced configuration validation to ensure `swiftgen.yml` files are correctly located and used in Xcode targets.
- Added methods to handle command creation specifically for Xcode build environments.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Plugin.swift</strong><dd><code>Add Xcode project support to SwiftGenPlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Plugins/SwiftGenPlugin/Plugin.swift

<li>Added support for <code>XcodeBuildToolPlugin</code> to <code>SwiftGenPlugin</code>.<br> <li> Implemented <code>createBuildCommands</code> method for Xcode build context.<br> <li> Added conditional imports and methods for Xcode project integration.<br> <li> Enhanced configuration validation and command creation for Xcode <br>targets.<br>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/SwiftGenPlugin/pull/3/files#diff-dcfaef2d1659ea3a7fdf9f156b01b13916da80e2e553a2aad3192f6ef717a40d">+63/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

